### PR TITLE
Create release 1.0.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -7,5 +7,5 @@ branches:
     increment: Minor
   release:
     regex: ^releases?[\/-](?<version>\d+\.\d+\.\d+)$
-    tag: 'rc'
+    label: 'rc'
     increment: None


### PR DESCRIPTION
Create release 1.0.0
+semver: major

This pull request updates the versioning configuration in `GitVersion.yml` to improve how release branches are detected and handled. The main change is the introduction of a new `release` branch configuration that uses a regex to identify release branches and assigns them a specific tag, while removing the previous custom version bump messages.

Branch and versioning configuration updates:

* Added a `release` branch configuration that uses a regex pattern to match release branches (e.g., `release/1.2.3` or `releases-1.2.3`), assigns the tag `rc`, and sets increment to `None`.
* Removed the custom version bump messages for major, minor, and patch increments, simplifying the configuration.